### PR TITLE
Feature(charts): Added autofocus functionality

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -443,6 +443,16 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(true);
   const isActivelySearching = isSearchFocused && !!searchInputValue;
 
+  // Auto-focus the search input when the component mounts (modal opens)
+  useEffect(() => {
+    if (searchInputRef.current) {
+      // Small delay to ensure modal is fully rendered
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 200);
+    }
+  }, []); // Empty dependency array means this runs once when component mounts
+
   const selectedVizMetadata: ChartMetadata | null = selectedViz
     ? mountedPluginMetadata[selectedViz]
     : null;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added auto-focus functionality to the search input when the modal component mounts for view charts. I debated between using an useEffect hook or a component lifecycle method, but I decided to use an useEffect hook because Apache Superset's frontend is built with modern React, so I should use functional components such as the useEffect hook.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: <img width="2556" height="1397" alt="Screenshot 2025-10-16 at 10 55 47 AM" src="https://github.com/user-attachments/assets/7cd31ba2-2151-4356-9d57-5ab16fed5590" />
After: 
<img width="2560" height="1397" alt="Screenshot 2025-10-16 at 10 56 30 AM" src="https://github.com/user-attachments/assets/abde09b9-3d48-42ba-b148-a96b6a45a281" />

Video Link: https://youtu.be/L6LhA-CgUgk 

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open any chart in Explore view
2. Click "Change Visualization Type" button
3. Modal opens
4. Verify cursor is automatically in the search input
5. Start typing immediately without clicking

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
Fixes #5 