### PR TITLE
bug: fixed sort descending control

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -372,7 +372,12 @@ const config: ControlPanelConfig = {
               description: t(
                 'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
               ),
-              visibility: isAggMode,
+              visibility: ({ controls }: ControlPanelsContainerProps) => {
+                const hasSortMetric = Boolean(
+                  controls?.timeseries_limit_metric?.value,
+                );
+                return hasSortMetric && isAggMode({ controls });
+              },
               resetOnHide: false,
             },
           },

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -308,6 +308,28 @@ const config: ControlPanelConfig = {
               resetOnHide: false,
             },
           },
+        ],
+        [
+          {
+            name: 'order_desc',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort descending'),
+              default: true,
+              description: t(
+                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) => {
+                const hasSortMetric = Boolean(
+                  controls?.timeseries_limit_metric?.value,
+                );
+                return hasSortMetric && isAggMode({ controls });
+              },
+              resetOnHide: false,
+            },
+          },
+        ],
+        [
           {
             name: 'order_by_cols',
             config: {
@@ -359,26 +381,6 @@ const config: ControlPanelConfig = {
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.server_pagination?.value),
-            },
-          },
-        ],
-        [
-          {
-            name: 'order_desc',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Sort descending'),
-              default: true,
-              description: t(
-                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
-              ),
-              visibility: ({ controls }: ControlPanelsContainerProps) => {
-                const hasSortMetric = Boolean(
-                  controls?.timeseries_limit_metric?.value,
-                );
-                return hasSortMetric && isAggMode({ controls });
-              },
-              resetOnHide: false,
             },
           },
         ],


### PR DESCRIPTION
<!---
fix(charts): fixed sort descending control
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The "Sort Descending" checkbox is always visible in the Table Chart control panel, regardless of whether a "Sort Query By" metric has been selected. Also, the checkbox appears below the server pagination controls, visually separated from the "Sort Query By" control it depends on.
I changed this by updating the visibility rule for the "Sort descending" checkbox to check for a selected sort metric. I removed the code for old placement of the checkbox and added some code to place it right below the "Sort Query By" control.
The "Sort Descending" checkbox is now only be visible when a "Sort Query By" metric is selected, making it clear that these two controls work together. The checkbox is also positioned directly below the "Sort Query By" control to visually indicate their relationship.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before Photo: 
<img width="2560" height="1349" alt="Screenshot 2025-10-26 at 9 33 55 PM" src="https://github.com/user-attachments/assets/43b801f0-ef48-475f-b089-ab3684aa2a8b" />
Before video: https://youtu.be/zCSJBhsRDQs
After Photo: 
<img width="2554" height="1341" alt="Screenshot 2025-10-26 at 11 08 43 PM" src="https://github.com/user-attachments/assets/6f1218a0-7afa-4c36-8e5c-375c2af0966a" />
After video: https://youtu.be/PQC0G9wM-uU


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Navigate to Charts > Top Timezones.
2. Select a metric in "Sort Queue By" Control and toggle the "Sort Descending".
3. Toggle the "Sort Descending" checkbox on and off.
4. Observe the functionality working as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
Fixes #10 