### PR TITLE
fix(charts): Browser tab title updating to chart name

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -151,6 +151,7 @@ export const hydrateExplore =
       controls: initialControls,
       form_data: initialFormData,
       slice: initialSlice,
+      sliceName: initialSlice?.slice_name ?? null,
       controlsTransferred: explore.controlsTransferred,
       standalone: getUrlParam(URL_PARAMS.standalone),
       force: getUrlParam(URL_PARAMS.force),

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -71,6 +71,8 @@ import DataSourcePanel from '../DatasourcePanel';
 import ConnectedExploreChartHeader from '../ExploreChartHeader';
 import ExploreContainer from '../ExploreContainer';
 
+const originalDocumentTitle = document.title;
+
 const propTypes = {
   ...ExploreChartPanel.propTypes,
   actions: PropTypes.object.isRequired,
@@ -374,6 +376,15 @@ function ExploreViewContainer(props) {
       addHistory({ isReplace: true });
     }
   });
+
+  useEffect(() => {
+    if (props.sliceName) {
+      document.title = props.sliceName;
+    }
+    return () => {
+      document.title = originalDocumentTitle;
+    };
+  }, [props.sliceName]);
 
   const previousHandlePopstate = usePrevious(handlePopstate);
   useEffect(() => {

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -116,6 +116,7 @@ export interface ExplorePageState {
     form_data: QueryFormData;
     hiddenFormData?: Partial<QueryFormData>;
     slice: Slice;
+    sliceName: string | null;
     controlsTransferred: string[];
     standalone: boolean;
     force: boolean;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(charts): Browser tab title updating to chart name
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a user opens a chart in Explore view, the browser tab title should automatically update to display the chart's name. When the user navigates away from the chart or dashboard, the tab title should reset to a default "Superset" title. This behavior should be consistent across both the Explore view (for charts) and Dashboard view. I did this by first putting the chart name is put into state on load, then typeScript declares the type and the original title is saved. Finally a useEffect updates the tab title and cleans up.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: <img width="2560" height="1394" alt="Screenshot 2025-11-02 at 9 04 44 PM" src="https://github.com/user-attachments/assets/4c9d0865-55ba-4b66-a7ef-f3f1a0895f10" />
Before video: https://youtu.be/gHN_MuiCge8 
After: <img width="2560" height="1385" alt="Screenshot 2025-11-02 at 11 18 12 PM" src="https://github.com/user-attachments/assets/07a33fbb-e33a-4e69-9432-f13684a61ded" />
After video: https://youtu.be/qvQDZV7XJXA


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Open Superset and navigate to an existing chart in Explore view
Verify the browser tab title displays the chart name
Open a different chart in a new tab
Verify the new tab shows the second chart's name
Navigate away from the chart (e.g., go to the home page)
Verify the tab title resets to "Superset"
Open a dashboard and verify its title appears in the tab
Navigate away from the dashboard
Verify the tab title resets to "Superset"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
Fixes #11 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Explore tab title to the chart name and resets on unmount; adds `sliceName` to state/types and wires it through props.
> 
> - **Explore UI behavior**:
>   - Set `document.title` to chart name in `src/explore/components/ExploreViewContainer/index.jsx`; restore original title on unmount.
> - **State & types**:
>   - Add `sliceName` to Explore Redux state in `hydrateExplore.ts` (initialized from `slice.slice_name`).
>   - Extend `ExplorePageState.explore` type with `sliceName` in `src/explore/types.ts`.
>   - Pass `sliceName` via `mapStateToProps` and through props to `ConnectedExploreChartHeader` and `SaveModal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a663cffbbc5f10f9019f38c79e46a89822e45cdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->